### PR TITLE
Plip 10359 - Security Control Panel migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Read ``allow_anon_views_about`` setting from the registry instead of portal
+  properties (see https://github.com/plone/Products.CMFPlone/issues/216).
+  [jcerjak]
 
 
 1.2.2 (2014-10-23)

--- a/plone/app/search/search.pt
+++ b/plone/app/search/search.pt
@@ -147,7 +147,7 @@
                                       <div class="search-type-options">
                                         <tal:div
                                            tal:define="typeLists python:context.createMultiColumnList(types_list, numCols=2, sort_on='self');"
-                                           
+
                                            tal:repeat="sublist typeLists">
                                           <tal:items repeat="type sublist">
                                             <div>
@@ -240,7 +240,7 @@
 
                     </dl>
 
-                    
+
                 </div>
 
 
@@ -275,8 +275,8 @@
                                                    toLocalizedTime nocall: context/@@plone/toLocalizedTime;
                                                    site_properties context/portal_properties/site_properties;
                                                    use_view_action site_properties/typesUseViewActionInListings|python:();
-                                                   allowAnonymousViewAbout site_properties/allowAnonymousViewAbout;
-                                                   show_about python:not isAnon or allowAnonymousViewAbout;">
+                                                   allow_anon_views_about python:context.portal_registry['plone.allow_anon_views_about'];
+                                                   show_about python:not isAnon or allow_anon_views_about;">
                           <ol class="searchResults">
                               <tal:results repeat="item batch">
                                     <li>


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362
