### PR TITLE
Fixed sometimes failing search order tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed sometimes failing search order tests.  [maurits]
 
 
 1.1.10 (2016-12-02)

--- a/plone/app/search/tests/base.py
+++ b/plone/app/search/tests/base.py
@@ -1,4 +1,5 @@
 import sys
+import time
 import unittest2 as unittest
 
 from zope.configuration import xmlconfig
@@ -56,12 +57,15 @@ class SearchLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.app.search:default')
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
-        for i in range(0, 100):
+        for i in range(0, 12):
             portal.invokeFactory(
                 'Document',
                 'my-page' + str(i),
                 text='spam spam ham eggs'
             )
+            # Sleep before creating the next one, otherwise ordering by date is
+            # not deterministic.
+            time.sleep(0.1)
         setRoles(portal, TEST_USER_ID, ['Member'])
 
         # Commit so that the test browser sees these objects

--- a/plone/app/search/tests/test_integration.py
+++ b/plone/app/search/tests/test_integration.py
@@ -76,8 +76,8 @@ class TestSection(SearchTestCase):
         res = portal.restrictedTraverse('@@search').results(query=q)
         ids = [r.getId() for r in res]
         expected = [
-            'my-page99', 'my-page98', 'my-page97', 'my-page96', 'my-page95',
-            'my-page94', 'my-page93', 'my-page92', 'my-page91', 'my-page90'
+            'my-page11', 'my-page10', 'my-page9', 'my-page8', 'my-page7',
+            'my-page6', 'my-page5', 'my-page4', 'my-page3', 'my-page2'
         ]
         self.assertEqual(ids, expected)
 
@@ -96,8 +96,8 @@ class TestSection(SearchTestCase):
         res = portal.restrictedTraverse('@@search').results(query=q)
         ids = [r.getId() for r in res]
         expected = [
-            'my-page10', 'my-page9', 'my-page8', 'my-page7', 'my-page6',
-            'my-page4', 'my-page3', 'my-page2', 'my-page1', 'my-page0'
+            'my-page11', 'my-page10', 'my-page9', 'my-page8', 'my-page7',
+            'my-page6', 'my-page4', 'my-page3', 'my-page2', 'my-page1'
         ]
         self.assertEqual(ids, expected)
 


### PR DESCRIPTION
This ports https://github.com/plone/Products.CMFPlone/pull/1865 to Plone 4.3, because the tests sometimes [fail there too](http://jenkins.plone.org/job/plone-4.3-python-2.6/1759/testReport/junit/plone.app.search.tests.test_integration/TestSection/).